### PR TITLE
Use PHP Intl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
+        "ext-intl": "*",
         "guzzlehttp/guzzle": "^7.2",
         "symfony/serializer": "^5.1",
         "symfony/property-access": "^5.1"

--- a/src/Model/LanguageCodes.php
+++ b/src/Model/LanguageCodes.php
@@ -9,46 +9,6 @@ use RuntimeException;
 
 class LanguageCodes
 {
-    const SPANISH = 'es';
-    const JAPANESE = 'ja';
-    const ENGLISH = 'en';
-    const ITALIAN = 'it';
-    const PORTUGUESE = 'pt';
-    const GERMAN = 'de';
-    const DUTCH = 'nl-NL';
-    const FRENCH = 'fr';
-    const KOREAN = 'ko';
-    const CHINESE = 'zh';
-    const RUSSIAN = 'ru';
-    const HINDI = 'hi';
-    const ARABIC = 'ar';
-    const TURKISH = 'tr';
-    const LATIN = 'la';
-    const SWEDISH = 'sv';
-    const GREEK = 'el';
-    const IRISH = 'ga';
-    const POLISH = 'pl';
-    const NORWEGIAN = 'no-BO';
-    const HEBREW = 'he';
-    const VIETNAMESE = 'vi';
-    const HAWAIIAN = 'hw';
-    const DANISH = 'da';
-    const SCOTS_GAELIC = 'gd';
-    const HIGH_VALYRIAN = 'hv';
-    const INDONESIAN = 'id';
-    const WELSH = 'cy';
-    const ROMANIAN = 'ro';
-    const CZECH = 'cs';
-    const SWAHILI = 'sw';
-    const FINNISH = 'fi';
-    const HUNGARIAN = 'hu';
-    const UKRAINIAN = 'uk';
-    const KLINGON = 'tlh';
-    const NAVAJO = 'nv';
-    const ESPERANTO = 'eo';
-    const CATALAN = 'ca';
-    const GUARANI = 'gn';
-
     public static function getCodeForDisplayName(string $name): string
     {
         $codesToNames = static::getCodesToNames();

--- a/src/Model/LanguageCodes.php
+++ b/src/Model/LanguageCodes.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Mickadoo\DuolingoEvents\Model;
 
+use Locale;
+use ResourceBundle;
 use RuntimeException;
 
 class LanguageCodes
@@ -65,134 +67,13 @@ class LanguageCodes
         );
     }
 
-    public static function getLanguageCodes()
+    public static function getLanguageCodes(): array
     {
-        return [
-            self::SPANISH,
-            self::JAPANESE,
-            self::ENGLISH,
-            self::ITALIAN,
-            self::PORTUGUESE,
-            self::GERMAN,
-            self::DUTCH,
-            self::FRENCH,
-            self::KOREAN,
-            self::CHINESE,
-            self::RUSSIAN,
-            self::HINDI,
-            self::ARABIC,
-            self::TURKISH,
-            self::LATIN,
-            self::SWEDISH,
-            self::GREEK,
-            self::IRISH,
-            self::POLISH,
-            self::NORWEGIAN,
-            self::HEBREW,
-            self::VIETNAMESE,
-            self::HAWAIIAN,
-            self::DANISH,
-            self::SCOTS_GAELIC,
-            self::HIGH_VALYRIAN,
-            self::INDONESIAN,
-            self::WELSH,
-            self::ROMANIAN,
-            self::CZECH,
-            self::SWAHILI,
-            self::FINNISH,
-            self::HUNGARIAN,
-            self::UKRAINIAN,
-            self::KLINGON,
-            self::NAVAJO,
-            self::ESPERANTO,
-            self::CATALAN,
-            self::GUARANI,
-        ];
+        return ResourceBundle::getLocales('');
     }
 
     public static function getDisplayNameForCode(string $code): string
     {
-        switch ($code) {
-            case self::SPANISH:
-                return 'Spanish';
-            case self::JAPANESE:
-                return 'Japanese';
-            case self::ENGLISH:
-                return 'English';
-            case self::ITALIAN:
-                return 'Italian';
-            case self::PORTUGUESE:
-                return 'Portuguese';
-            case self::GERMAN:
-                return 'German';
-            case self::DUTCH:
-                return 'Dutch';
-            case self::FRENCH:
-                return 'French';
-            case self::KOREAN:
-                return 'Korean';
-            case self::CHINESE:
-                return 'Chinese';
-            case self::RUSSIAN:
-                return 'Russian';
-            case self::HINDI:
-                return 'Hindi';
-            case self::ARABIC:
-                return 'Arabic';
-            case self::TURKISH:
-                return 'Turkish';
-            case self::LATIN:
-                return 'Latin';
-            case self::SWEDISH:
-                return 'Swedish';
-            case self::GREEK:
-                return 'Greek';
-            case self::IRISH:
-                return 'Irish';
-            case self::POLISH:
-                return 'Polish';
-            case self::NORWEGIAN:
-                return 'Norwegian';
-            case self::HEBREW:
-                return 'Hebrew';
-            case self::VIETNAMESE:
-                return 'Vietnamese';
-            case self::HAWAIIAN:
-                return 'Hawaiian';
-            case self::DANISH:
-                return 'Danish';
-            case self::SCOTS_GAELIC:
-                return 'Scottish Gaelic';
-            case self::HIGH_VALYRIAN:
-                return 'High Valyrian';
-            case self::INDONESIAN:
-                return 'Indonesian';
-            case self::WELSH:
-                return 'Welsh';
-            case self::ROMANIAN:
-                return 'Romanian';
-            case self::CZECH:
-                return 'Czech';
-            case self::SWAHILI:
-                return 'Swahili';
-            case self::FINNISH:
-                return 'Finnish';
-            case self::HUNGARIAN:
-                return 'Hungarian';
-            case self::UKRAINIAN:
-                return 'Ukrainian';
-            case self::KLINGON:
-                return 'Klingon';
-            case self::NAVAJO:
-                return 'Navajo';
-            case self::ESPERANTO:
-                return 'Esperanto';
-            case self::CATALAN:
-                return 'Catalan';
-            case self::GUARANI:
-                return 'Guarani';
-        }
-
-        throw new RuntimeException(sprintf('Cannot find language code "%s"', $code));
+        return Locale::getDisplayName($code);
     }
 }

--- a/test/EventsIntegrationTest.php
+++ b/test/EventsIntegrationTest.php
@@ -8,7 +8,6 @@ use GuzzleHttp\Psr7\Response;
 use Mickadoo\DuolingoEvents\ApiFactory;
 use Mickadoo\DuolingoEvents\EventsApi;
 use Mickadoo\DuolingoEvents\Model\Event;
-use Mickadoo\DuolingoEvents\Model\LanguageCodes;
 use Mickadoo\DuolingoEvents\Normalizer\EventDenormalizer;
 use Mickadoo\DuolingoEvents\Request\EventsRequest;
 use PHPUnit\Framework\TestCase;
@@ -36,10 +35,10 @@ class EventsIntegrationTest extends TestCase
     {
         $api = $this->getApi();
         $request = new EventsRequest();
-        $request->setLanguageCodes([LanguageCodes::FRENCH]);
+        $request->setLanguageCodes(['fr']);
         $results = $api->getEvents($request);
         foreach ($results as $result) {
-            $this->assertContains(LanguageCodes::FRENCH, $result->getLanguages());
+            $this->assertContains('fr', $result->getLanguages());
         }
     }
 


### PR DESCRIPTION
## Overview

Instead of using a hardcoded list of languages, which needs to be updated if Duolingo adds an event in a new language, it would be better to use PHP built-in locale support.

This PR requires the PHP extension `php-intl` and uses its functionality to replaced the hardcoded language codes.