### PR TITLE
Map locales to languages

### DIFF
--- a/src/Model/LanguageCodes.php
+++ b/src/Model/LanguageCodes.php
@@ -29,7 +29,13 @@ class LanguageCodes
 
     public static function getLanguageCodes(): array
     {
-        return ResourceBundle::getLocales('');
+        $locales = ResourceBundle::getLocales('');
+        $languages = array_map(function ($locale) {
+            return Locale::getPrimaryLanguage($locale);
+        }, $locales);
+        $extraLanguages = ['thk']; // Klingon
+
+        return array_unique(array_merge($languages, $extraLanguages));
     }
 
     public static function getDisplayNameForCode(string $code): string

--- a/test/Model/LanguageCodesTest.php
+++ b/test/Model/LanguageCodesTest.php
@@ -17,4 +17,9 @@ class LanguageCodesTest extends TestCase
             $this->assertEquals($name, LanguageCodes::getDisplayNameForCode($code));
         }
     }
+
+    public function testWillIncludeNonStandardLanguagesLikeKlingon()
+    {
+        $this->assertEquals('Klingon', LanguageCodes::getDisplayNameForCode('tlh'));
+    }
 }


### PR DESCRIPTION
## Overview

The language code class was using just a list of locale, which is more than we need. We can map these to primary languages, which we're more interested in.